### PR TITLE
Fix tooltip loader typo

### DIFF
--- a/_javascript/modules/components/tooltip-loader.js
+++ b/_javascript/modules/components/tooltip-loader.js
@@ -1,7 +1,7 @@
 /**
  * Initial Bootstrap Tooltip.
  */
-export function loadTooptip() {
+export function loadTooltip() {
   const tooltipTriggerList = document.querySelectorAll(
     '[data-bs-toggle="tooltip"]'
   );

--- a/_javascript/modules/layouts/basic.js
+++ b/_javascript/modules/layouts/basic.js
@@ -1,7 +1,7 @@
 import { back2top } from '../components/back-to-top';
-import { loadTooptip } from '../components/tooltip-loader';
+import { loadTooltip } from '../components/tooltip-loader';
 
 export function basic() {
   back2top();
-  loadTooptip();
+  loadTooltip();
 }


### PR DESCRIPTION
## Summary
- fix method name typo for tooltip loader

## Testing
- `npm run test` *(fails: needs packages)*

------
https://chatgpt.com/codex/tasks/task_e_6841b13d0fe4832ab7f35074e3418a32